### PR TITLE
Made samples runnable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -250,3 +250,7 @@ paket-files/
 # JetBrains Rider
 .idea/
 *.sln.iml
+
+# Samples
+samples/*/app/*
+samples/*/temp/*

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ sudo npm install -g electron
  
 ### 2. Compile JS from .FSX
 
-Every samples have a `fableconfig.json` file which contains configurations for fable. The only command needed is then `fable`:
+Every samples have a `fableconfig.json` file which contains configurations for fable. The only command needed is `fable`:
 
 ```
 bash-3.2$ cd samples/material-ui/                                                                                                                                                                                                                                   
@@ -54,7 +54,7 @@ renderer.js.map  1.54 MB       1  [emitted]  renderer
 
 ### 3. Run electron sample
 
-When the compilation is done, there should be a `app/js/main.js`.
+When the compilation is done, there should be a `app/js/main.js` file.
 It is the entrypoint for electron.
 
 To run the sample execute the following command:
@@ -64,4 +64,10 @@ bash-3.2$ npm run start
                                                                                                                                                                                                                                                                     
 > @ start /Users/[USERNAME]/Projects/fable-electron/samples/material-ui                                                                                                                                                                                            
 > electron app/js/main.js 
+```
+
+or 
+
+```
+bash-3.2$ electron app/js/main.js
 ```

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ or
 sudo npm install -g electron
 ```
  
-### 2. Navigate to any of the samples
+### 2. Compile JS from .FSX
 
 Every samples have a `fableconfig.json` file which contains configurations for fable. The only command needed is then `fable`:
 

--- a/README.md
+++ b/README.md
@@ -2,10 +2,17 @@
 
 Fable bindings and samples for Github Electron
 
-## How to run the samples?
+## What's electron?
+
+> The Electron framework lets you write cross-platform desktop applications using JavaScript, HTML and CSS. It is based on Node.js and Chromium and is used by the Atom editor and many other apps.
+> https://github.com/electron/electron
 
 Electron documentation official website: 
-[http://electron.atom.io/](http://electron.atom.io/)
+[http://electron.atom.io/docs/](http://electron.atom.io/docs/)
+
+
+## How to run the samples?
+
 
 ### 1. Install electron
 

--- a/README.md
+++ b/README.md
@@ -7,10 +7,6 @@ Fable bindings and samples for Github Electron
 > The Electron framework lets you write cross-platform desktop applications using JavaScript, HTML and CSS. It is based on Node.js and Chromium and is used by the Atom editor and many other apps.
 > https://github.com/electron/electron
 
-Electron documentation official website: 
-[http://electron.atom.io/docs/](http://electron.atom.io/docs/)
-
-
 ## How to run the samples?
 
 

--- a/README.md
+++ b/README.md
@@ -9,14 +9,23 @@ Fable bindings and samples for Github Electron
 
 ## How to run the samples?
 
-
 ### 1. Install electron
 
-`npm install -g electron`
+To run the samples, `electron` needs to be available globally and in `PATH`.
+
+```
+npm install -g electron
+```
+
+or
+
+```
+sudo npm install -g electron
+```
  
 ### 2. Navigate to any of the samples
 
-Every sample have a `fableconfig.json` file, so you only need to run:
+Every samples have a `fableconfig.json` file which contains configurations for fable. The only command needed is then `fable`:
 
 ```
 bash-3.2$ cd samples/material-ui/                                                                                                                                                                                                                                   

--- a/README.md
+++ b/README.md
@@ -1,2 +1,55 @@
 # fable-electron
+
 Fable bindings and samples for Github Electron
+
+## How to run the samples?
+
+Electron documentation official website: 
+[http://electron.atom.io/](http://electron.atom.io/)
+
+### 1. Install electron
+
+`npm install -g electron`
+ 
+### 2. Navigate to any of the samples
+
+Every sample have a `fableconfig.json` file, so you only need to run:
+
+```
+bash-3.2$ cd samples/material-ui/                                                                                                                                                                                                                                   
+bash-3.2$ fable 
+```
+
+The `npm` packages should install and fable will compile the `fsx`.
+
+```
+bash-3.2$ fable                                                                                                                                                                                                                                                     
+npm install                                                                                                                                                                                                                                                         
+fable-compiler 0.5.6: Start compilation...                                                                                                                                                                                                                          
+Compiled renderer.fsx at 5:49:52 PM                                                                                                                                                                                                                                 
+Compiled main.fsx at 5:49:52 PM                                                                                                                                                                                                                                     
+node node_modules/webpack/bin/webpack                                                                                                                                                                                                                               
+Hash: 7cbedbac26f715a9ccf7                                                                                                                                                                                                                                          
+Version: webpack 1.13.2                                                                                                                                                                                                                                             
+Time: 1766ms                                                                                                                                                                                                                                                        
+          Asset     Size  Chunks             Chunk Names                                                                                                                                                                                                            
+        main.js  2.83 kB       0  [emitted]  main                                                                                                                                                                                                                   
+    renderer.js  1.29 MB       1  [emitted]  renderer                                                                                                                                                                                                               
+    main.js.map  3.24 kB       0  [emitted]  main                                                                                                                                                                                                                   
+renderer.js.map  1.54 MB       1  [emitted]  renderer                                                                                                                                                                                                               
+    + 371 hidden modules    
+```
+
+### 3. Run electron sample
+
+When the compilation is done, there should be a `app/js/main.js`.
+It is the entrypoint for electron.
+
+To run the sample execute the following command:
+
+```
+bash-3.2$ npm run start                                                                                                                                                                                                                                             
+                                                                                                                                                                                                                                                                    
+> @ start /Users/[USERNAME]/Projects/fable-electron/samples/material-ui                                                                                                                                                                                            
+> electron app/js/main.js 
+```

--- a/samples/dc/package.json
+++ b/samples/dc/package.json
@@ -12,7 +12,7 @@
   "devDependencies": {
     "electron-prebuilt": "^1.2.5",
     "fable-import-d3": "0.0.2",
-    "fable-import-dc": "^0.0.1",
+    "fable-import-dc": "^0.0.2",
     "fable-import-electron": "^0.0.5",
     "source-map-loader": "^0.1.5",
     "webpack": "^1.13.1"

--- a/samples/dc/src/renderer.fsx
+++ b/samples/dc/src/renderer.fsx
@@ -1,14 +1,13 @@
 // Load Fable.Core and bindings to JS global objects
-#r "../../../../build/fable/bin/Fable.Core.dll"
+#r "../node_modules/fable-core/Fable.Core.dll"
 #load "../node_modules/fable-import-d3/Fable.Import.D3.fs"
-// #load "../node_modules/fable-import-dc/Fable.Import.DC.fs"
-#load "../../../../import/dc/Fable.Import.DC.fs"
+#load "../node_modules/fable-import-dc/Fable.Import.DC.fs"
 
 open System
 open Fable.Core
 open Fable.Core.JsInterop
 open Fable.Import
-type dc = Fable.Import.DC.Globals
+type dc = Fable.Import.dc.Globals
 
 let crossfilter = importDefault<obj->obj> "crossfilter"
 
@@ -29,13 +28,13 @@ D3.Globals.csv.Invoke("data/morley.csv", fun error experiments ->
             ?reduceSum(fun d -> (+d?Speed * +d?Run) / 1000)
 
     chart
-        .width(768.)
-        .height(480.)
-        .x(D3.Scale.Globals.linear().domain([|6.;20.|]))
-        .dimension(runDimension)
-        .group(speedSumGroup)
-        .on("renderlet", fun chart ->
-            chart.selectAll("rect")?on("click", fun d ->
+        .width.Invoke(768.)
+        .height.Invoke(480.)
+        .x.Invoke(D3.Scale.Globals.linear().domain([|6.;20.|]))
+        .dimension.Invoke(runDimension)
+        .group.Invoke(speedSumGroup)
+        .on.Invoke("renderlet", fun chart ->
+            chart.selectAll.Invoke("rect")?on("click", fun d ->
                 Browser.console.log("click!", d)
             ) |> ignore
         )

--- a/samples/dc/src/renderer.fsx
+++ b/samples/dc/src/renderer.fsx
@@ -7,7 +7,7 @@ open System
 open Fable.Core
 open Fable.Core.JsInterop
 open Fable.Import
-type dc = Fable.Import.dc.Globals
+type dc = Fable.Import.DC.Globals
 
 let crossfilter = importDefault<obj->obj> "crossfilter"
 
@@ -28,13 +28,13 @@ D3.Globals.csv.Invoke("data/morley.csv", fun error experiments ->
             ?reduceSum(fun d -> (+d?Speed * +d?Run) / 1000)
 
     chart
-        .width.Invoke(768.)
-        .height.Invoke(480.)
-        .x.Invoke(D3.Scale.Globals.linear().domain([|6.;20.|]))
-        .dimension.Invoke(runDimension)
-        .group.Invoke(speedSumGroup)
-        .on.Invoke("renderlet", fun chart ->
-            chart.selectAll.Invoke("rect")?on("click", fun d ->
+        .width(768.)
+        .height(480.)
+        .x(D3.Scale.Globals.linear().domain([|6.;20.|]))
+        .dimension(runDimension)
+        .group(speedSumGroup)
+        .on("renderlet", fun chart ->
+            chart.selectAll("rect")?on("click", fun d ->
                 Browser.console.log("click!", d)
             ) |> ignore
         )

--- a/samples/material-ui/src/renderer.fsx
+++ b/samples/material-ui/src/renderer.fsx
@@ -1,7 +1,7 @@
 // Load Fable.Core and bindings to JS global objects
-#r "../../../../build/fable/bin/Fable.Core.dll"
-#load "../../../../import/react/Fable.Import.React.fs"
-#load "../../../../import/react/Fable.Helpers.React.fs"
+#r "../node_modules/fable-core/Fable.Core.dll"
+#load "../node_modules/fable-import-react/Fable.Import.React.fs"
+#load "../node_modules/fable-import-react/Fable.Helpers.React.fs"
 
 open System
 open Fable.Core


### PR DESCRIPTION
The samples weren't runnable, possibly due to the recent commit _Move Electron bindings and samples from Fable repo_ (https://github.com/fable-compiler/fable-electron/commit/3ec0fe59ce86e93fce009bf4a28c4a3fbf02f790).

I also updated the README to provide information on what Electron is and provide instructions on how to run the samples to get started quicker.