### PR TITLE
Update BrowserWindowOptions properties

### DIFF
--- a/npm/Fable.Import.Electron.fs
+++ b/npm/Fable.Import.Electron.fs
@@ -259,14 +259,15 @@ module Electron =
         abstract flags: ResizeArray<ThumbarButtonFlags> option with get, set
 
     and WebPreferences =
+        abstract devTools: bool option with get, set
         abstract nodeIntegration: bool option with get, set
+        abstract nodeIntegrationWorker: bool option with get, set
         abstract preload: string option with get, set
         abstract session: Session option with get, set
         abstract partition: string option with get, set
         abstract zoomFactor: float option with get, set
         abstract javascript: bool option with get, set
         abstract webSecurity: bool option with get, set
-        abstract allowDisplayingInsecureContent: bool option with get, set
         abstract allowRunningInsecureContent: bool option with get, set
         abstract images: bool option with get, set
         abstract textAreasAreResizable: bool option with get, set
@@ -275,14 +276,18 @@ module Electron =
         abstract plugins: bool option with get, set
         abstract experimentalFeatures: bool option with get, set
         abstract experimentalCanvasFeatures: bool option with get, set
-        abstract directWrite: bool option with get, set
+        abstract scrollBounce: bool option with get, set
         abstract blinkFeatures: string option with get, set
+        abstract disableBlinkFeatures: string option with get, set
         abstract defaultFontFamily: obj option with get, set
         abstract defaultFontSize: float option with get, set
         abstract defaultMonospaceFontSize: float option with get, set
         abstract minimumFontSize: float option with get, set
         abstract defaultEncoding: string option with get, set
         abstract backgroundThrottling: bool option with get, set
+        abstract offscreen: bool option with get, set
+        abstract sandbox: bool option with get, set
+        abstract contextIsolation: bool option with get, set
 
     and BrowserWindowOptions =
         inherit Rectangle
@@ -301,6 +306,7 @@ module Electron =
         abstract minimizable: bool option with get, set
         abstract maximizable: bool option with get, set
         abstract closable: bool option with get, set
+        abstract focusable: bool option with get, set
         abstract alwaysOnTop: bool option with get, set
         abstract fullscreen: bool option with get, set
         abstract fullscreenable: bool option with get, set
@@ -310,6 +316,8 @@ module Electron =
         abstract icon: U2<NativeImage, string> option with get, set
         abstract show: bool option with get, set
         abstract frame: bool option with get, set
+        abstract parent: BrowserWindow option with get, set
+        abstract model: bool option with get, set
         abstract acceptFirstMouse: bool option with get, set
         abstract disableAutoHideCursor: bool option with get, set
         abstract autoHideMenuBar: bool option with get, set
@@ -320,6 +328,9 @@ module Electron =
         abstract transparent: bool option with get, set
         abstract ``type``: BrowserWindowType option with get, set
         abstract titleBarStyle: string option with get, set
+        abstract thickFrame: bool option with get, set
+        abstract vibrancy: string option with get, set
+        abstract zoomToPageWidth: bool option with get, set
         abstract webPreferences: WebPreferences option with get, set
 
     and BrowserWindowType =

--- a/npm/Fable.Import.Electron.fs
+++ b/npm/Fable.Import.Electron.fs
@@ -317,7 +317,7 @@ module Electron =
         abstract show: bool option with get, set
         abstract frame: bool option with get, set
         abstract parent: BrowserWindow option with get, set
-        abstract model: bool option with get, set
+        abstract modal: bool option with get, set
         abstract acceptFirstMouse: bool option with get, set
         abstract disableAutoHideCursor: bool option with get, set
         abstract autoHideMenuBar: bool option with get, set

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fable-import-electron",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Fable bindings for Electron",
   "repository": {
     "type": "git",


### PR DESCRIPTION
I wanted to open a child window using `parent` and `modal` and noticed the properties were missing. Using [the list from the docs](https://github.com/electron/electron/blob/master/docs/api/browser-window.md#new-browserwindowoptions), I updated all the properties to the latest.