### PR TITLE
fix(ci): Build system on cloud CI should be more resilient to errors …

### DIFF
--- a/ci/Build.fs
+++ b/ci/Build.fs
@@ -141,7 +141,20 @@ Target.create Ops.push (fun _ ->
     Target.deactivateFinal Ops.gitnet)
 
 Target.create Ops.generateApiDocs (ignore >> ApiDocs.validateDir >> ApiDocs.build)
-Target.create Ops.setupTest (fun _ -> Electron.installTests Args.npmCi)
+Target.create Ops.setupTest (fun _ ->
+    // If the CI fails because of a lock file error, then we'll do a standard install first
+    // to update the lock file, try again, and then fallback again to a clean install if that also fails.
+    try Electron.installTests Args.npmCi with
+    | e when
+        Args.npmCi
+        && (e.Message.Contains("code EUSAGE")
+            || e.Message.Contains("Please update your lock file with `npm install`")) ->
+        try
+        Electron.installTests false
+        with
+        | _ -> Electron.installTests true
+    | _ -> reraise()
+)
 
 Target.create Ops.test
 <| function


### PR DESCRIPTION
I've noticed there's been weeks of the generator failing and not raising tickets because [it fails during setup](https://github.com/fable-hub/Fable.Electron/actions/runs/24622530622/job/71995748962#step:7:84).

The error is pretty benign, I'm no expert on npm so I've just added a guard which runs a normal install if the error description asks for it when running a `npm ci`.